### PR TITLE
chore: add missing dependabot entries

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -128,6 +128,34 @@ updates:
         patterns:
           - "org.apache.maven.plugins:*"
 
+  - package-ecosystem: "maven"
+    directory: "/customer-360/java"
+    schedule:
+      interval: weekly
+      day: "sunday"
+    open-pull-requests-limit: 20
+    groups:
+      arcadedb:
+        patterns:
+          - "com.arcadedb:*"
+      maven-plugins:
+        patterns:
+          - "org.apache.maven.plugins:*"
+
+  - package-ecosystem: "maven"
+    directory: "/social-network-analytics/java"
+    schedule:
+      interval: weekly
+      day: "sunday"
+    open-pull-requests-limit: 20
+    groups:
+      arcadedb:
+        patterns:
+          - "com.arcadedb:*"
+      maven-plugins:
+        patterns:
+          - "org.apache.maven.plugins:*"
+
   # ── npm ────────────────────────────────────────────────────────────────────
   - package-ecosystem: "npm"
     directory: "/supply-chain/js"
@@ -221,6 +249,28 @@ updates:
 
   - package-ecosystem: "docker-compose"
     directory: "/iam"
+    schedule:
+      interval: weekly
+      day: "sunday"
+    open-pull-requests-limit: 10
+    groups:
+      arcadedb-docker:
+        patterns:
+          - "arcadedata/arcadedb"
+
+  - package-ecosystem: "docker-compose"
+    directory: "/customer-360"
+    schedule:
+      interval: weekly
+      day: "sunday"
+    open-pull-requests-limit: 10
+    groups:
+      arcadedb-docker:
+        patterns:
+          - "arcadedata/arcadedb"
+
+  - package-ecosystem: "docker-compose"
+    directory: "/social-network-analytics"
     schedule:
       interval: weekly
       day: "sunday"


### PR DESCRIPTION
## Summary

- Add `customer-360` Maven and Docker Compose entries to dependabot
- Add `social-network-analytics` Maven and Docker Compose entries to dependabot

Both use cases were missing from `.github/dependabot.yml`.

## Test plan

- [ ] Dependabot picks up the new directories on next scheduled run

🤖 Generated with [Claude Code](https://claude.com/claude-code)