### PR TITLE
ci: add aggregator workflow to test all modules in one call

### DIFF
--- a/.github/workflows/all-modules.yml
+++ b/.github/workflows/all-modules.yml
@@ -1,0 +1,41 @@
+name: All Modules CI
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Weekly full run, Mondays 04:00 UTC
+    - cron: "0 4 * * 1"
+
+permissions:
+  contents: read
+
+jobs:
+  customer-360:
+    uses: ./.github/workflows/customer-360.yml
+
+  feature-store:
+    uses: ./.github/workflows/feature-store.yml
+
+  fraud-detection:
+    uses: ./.github/workflows/fraud-detection.yml
+
+  graph-rag:
+    uses: ./.github/workflows/graph-rag.yml
+
+  iam:
+    uses: ./.github/workflows/iam.yml
+
+  knowledge-graphs:
+    uses: ./.github/workflows/knowledge-graphs.yml
+
+  realtime-analytics:
+    uses: ./.github/workflows/realtime-analytics.yml
+
+  recommendation-engine:
+    uses: ./.github/workflows/recommendation-engine.yml
+
+  social-network-analytics:
+    uses: ./.github/workflows/social-network-analytics.yml
+
+  supply-chain:
+    uses: ./.github/workflows/supply-chain.yml

--- a/.github/workflows/all-modules.yml
+++ b/.github/workflows/all-modules.yml
@@ -9,6 +9,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: all-modules-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   customer-360:
     uses: ./.github/workflows/customer-360.yml

--- a/.github/workflows/customer-360.yml
+++ b/.github/workflows/customer-360.yml
@@ -1,6 +1,7 @@
 name: Customer 360 CI
 
 on:
+  workflow_call:
   push:
     paths:
       - customer-360/**

--- a/.github/workflows/feature-store.yml
+++ b/.github/workflows/feature-store.yml
@@ -1,6 +1,7 @@
 name: Feature Store CI
 
 on:
+  workflow_call:
   push:
     paths:
       - feature-store/**

--- a/.github/workflows/fraud-detection.yml
+++ b/.github/workflows/fraud-detection.yml
@@ -1,6 +1,7 @@
 name: Fraud Detection CI
 
 on:
+  workflow_call:
   push:
     paths:
       - fraud-detection/**

--- a/.github/workflows/graph-rag.yml
+++ b/.github/workflows/graph-rag.yml
@@ -1,6 +1,7 @@
 name: Graph RAG CI
 
 on:
+  workflow_call:
   push:
     paths:
       - graph-rag/**

--- a/.github/workflows/iam.yml
+++ b/.github/workflows/iam.yml
@@ -1,6 +1,7 @@
 name: IAM CI
 
 on:
+  workflow_call:
   push:
     paths:
       - iam/**

--- a/.github/workflows/knowledge-graphs.yml
+++ b/.github/workflows/knowledge-graphs.yml
@@ -1,6 +1,7 @@
 name: Knowledge Graph CI
 
 on:
+  workflow_call:
   push:
     paths:
       - knowledge-graphs/**

--- a/.github/workflows/realtime-analytics.yml
+++ b/.github/workflows/realtime-analytics.yml
@@ -1,6 +1,7 @@
 name: Realtime Analytics CI
 
 on:
+  workflow_call:
   push:
     paths:
       - realtime-analytics/**

--- a/.github/workflows/recommendation-engine.yml
+++ b/.github/workflows/recommendation-engine.yml
@@ -1,6 +1,7 @@
 name: Recommendation Engine CI
 
 on:
+  workflow_call:
   push:
     paths:
       - recommendation-engine/**

--- a/.github/workflows/social-network-analytics.yml
+++ b/.github/workflows/social-network-analytics.yml
@@ -1,6 +1,7 @@
 name: Social Network Analytics CI
 
 on:
+  workflow_call:
   push:
     paths:
       - social-network-analytics/**

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -1,6 +1,7 @@
 name: Supply Chain CI
 
 on:
+  workflow_call:
   push:
     paths:
       - supply-chain/**


### PR DESCRIPTION
Add .github/workflows/all-modules.yml, which fans out to every use-case workflow via `uses:`. Triggered manually with workflow_dispatch, plus a weekly Monday 04:00 UTC cron to catch drift in the ArcadeDB Docker images and Maven dependencies between commits.

Each use-case workflow gains a `workflow_call:` trigger so it can be invoked as a reusable workflow. Existing push/pull_request path filters are unchanged, so per-module CI behaves exactly as before.